### PR TITLE
Minor fix for unnecessary operations.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,3 +2,4 @@ The following organization or individuals have contributed to TraceCode:
 
 - nexB Inc.
 - Philippe Ombredanne
+- Dong-hee Na

--- a/src/tracecode/tracecode.py
+++ b/src/tracecode/tracecode.py
@@ -108,13 +108,13 @@ def validate_traces(input_dir):
             if ts and len(ts) >= 1:
                 ts = float(ts[0])
 
-            if oldest_ts:
-                if ts <= oldest_ts:
+                if oldest_ts:
+                    if ts <= oldest_ts:
+                        oldest_ts = ts
+                        oldest_pid = pid
+                else:
                     oldest_ts = ts
                     oldest_pid = pid
-            else:
-                oldest_ts = ts
-                oldest_pid = pid
 
         # store a process trace by id
         traces[pid] = path


### PR DESCRIPTION
For this weekend, I am going to read your repos.
Actually, this PR is not significant.
Just one thing I noticed, while I read your code. 
There was an unnecessary operations which is to find the smallest pid.

If `ts` does not exist, it doesn't have to compare old one.